### PR TITLE
Better deployment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,8 +22,9 @@ var test = 'test/**/*';
  */
 var languages = {
   js: {
-    repo: 'Asana/node-asana-gen',
-    destPath: 'lib',
+    repo: 'Asana/node-asana',
+    branch: 'api-meta-incoming',
+    destPath: 'lib/resources/gen',
     resourceBaseName: function(resource) {
       return helpers('js').plural(resource);
     },
@@ -101,7 +102,16 @@ Object.keys(languages).forEach(function(lang) {
           ? util.format('https://github.com/%s', config.repo)
           : util.format('git@github.com:%s', config.repo);
       echoAndExec(
-          util.format('git clone --depth=1 %s %s', url, repoRoot),
+          util.format('git clone %s %s', url, repoRoot),
+          switchToBranch);
+    }
+
+    function switchToBranch(err, stdout, stderr) {
+      if (err) { cb(err); return; }
+      var branch = config.branch;
+      echoAndExec(
+          util.format('git checkout --track -b %s origin/%s', branch, branch),
+          {cwd: repoRoot},
           configureCredentials);
     }
 
@@ -151,7 +161,9 @@ Object.keys(languages).forEach(function(lang) {
 
     function gitPush(err) {
       if (err) { cb(err); return; }
-      echoAndExec('git push --tags origin master', {cwd: repoRoot}, function(err, stdout, stderr) {
+      echoAndExec(
+          util.format('git push --tags origin %s', config.branch),
+          {cwd: repoRoot}, function(err, stdout, stderr) {
         if (err) { cb(err); return; }
         // Finally, success!
         cb();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,10 +24,8 @@ var languages = {
   js: {
     repo: 'Asana/node-asana',
     branch: 'api-meta-incoming',
-    destPath: 'lib/resources/gen',
-    resourceBaseName: function(resource) {
-      return helpers('js').plural(resource);
-    },
+    templatePath: 'src/templates',
+    outputPath: 'lib/resources/gen',
     updatePackage: function(version, cb) {
       var repoRoot = paths.repo('js');
       var destPackage = readPackage(repoRoot + '/package.json');
@@ -45,11 +43,11 @@ var paths = {
   repo: function(lang) {
     return 'dist/git/' + lang;
   },
-  repoDest: function(lang) {
-    return paths.repo(lang) + '/' + paths.repoDestRelative(lang);
+  repoOutput: function(lang) {
+    return paths.repo(lang) + '/' + paths.repoOutputRelative(lang);
   },
-  repoDestRelative: function(lang) {
-    return languages[lang].destPath;
+  repoOutputRelative: function(lang) {
+    return languages[lang].outputPath;
   }
 };
 
@@ -76,26 +74,42 @@ gulp.task('deploy', ['ensure-git-clean', 'build'].concat(Object.keys(languages).
 })));
 
 /**
- * Generate deploy rules for each language
+ * Generate build and deploy rules for each language
  */
+var resourceNames = resource.names();
 Object.keys(languages).forEach(function(lang) {
-  gulp.task('deploy-' + lang, ['build-' + lang], function(cb) {
-    var config = languages[lang];
-    var dest = paths.repoDest(lang);
-    var repoRoot = paths.repo(lang);
-    var token = process.env.ASANA_GITHUB_TOKEN || null;
-    var version;
+  var config = languages[lang];
+  var outputPath = paths.repoOutput(lang);
+  var repoRoot = paths.repo(lang);
+  var token = process.env.ASANA_GITHUB_TOKEN || null;
 
-    function echoAndExec() {
-      if (process.env.GULP_DEBUG) {
-        console.log('+ ' + arguments[0]);
-      }
-      return exec.apply(null, arguments);
+  function echoAndExec() {
+    if (process.env.GULP_DEBUG) {
+      console.log('+ ' + arguments[0]);
     }
+    return exec.apply(null, arguments);
+  }
+
+  function resTaskName(resourceName) {
+    return 'build-' + lang + '-' + resourceName;
+  }
+
+  /**
+   * Clean work area for target repo
+   */
+  Object.keys(languages).forEach(function(lang) {
+    gulp.task('clean-' + lang, function() {
+      fs.removeSync(paths.dist(lang));
+    });
+  });
+
+  /**
+   * Checkout target repo, for build and deploy
+   */
+  gulp.task('checkout-' + lang, ['clean-', lang], function(cb) {
 
     cloneRepo(cb);
 
-    // TODO: use some kind of promisify libraries to clean all this async code
     function cloneRepo(cb) {
       fs.removeSync(repoRoot);
       var url = (token !== null)
@@ -112,8 +126,56 @@ Object.keys(languages).forEach(function(lang) {
       echoAndExec(
           util.format('git checkout --track -b %s origin/%s', branch, branch),
           {cwd: repoRoot},
-          configureCredentials);
+          done);
     }
+
+    function done(err, stdout, stderr) {
+      if (err) { cb(err); return; }
+      cb();
+    }
+  });
+
+  /**
+   * Build rules, per resource.
+   */
+  resourceNames.forEach(function(resourceName) {
+    gulp.task(resTaskName(resourceName), function() {
+      // Support templates existing either locally or in target repo.
+      var templatePath = config.templatePath ?
+          (paths.repo(lang) + '/' + config.templatePath):
+          ('src/templates/' + lang);
+      var resourceTemplateInfo = require(templatePath).resource;
+
+      // Find the template info for resources
+      var resource = resource.load(resourceName);
+      var templateHelpers = helpers(lang);
+      return gulp.src(templatePath + '/' + resourceTemplateInfo.template)
+          .pipe(
+              template(resource, {
+                imports: templateHelpers,
+                variable: 'resource'
+              }))
+          .pipe(
+              rename(resourceTemplateInfo.filename(resource, templateHelpers)))
+          .pipe(
+              gulp.dest(paths.dist(lang)));
+    });
+  });
+  gulp.task(
+      'build-' + lang,
+      ['checkout-' + lang].concat(resourceNames.map(resTaskName)));
+
+  /**
+   * Deploy
+   */
+  gulp.task('deploy-' + lang, ['build-' + lang], function(cb) {
+    var version;
+
+    // We depend on the build step which checks out the repo, so we start by
+    // setting our credentials so we can push to it.
+    configureCredentials();
+
+    // TODO: use some kind of promisify libraries to clean all this async code
 
     function configureCredentials(err, stdout, stderr) {
       if (err) { cb(err); return; }
@@ -137,8 +199,8 @@ Object.keys(languages).forEach(function(lang) {
 
     function copyToRepo(err, stdout, stderr) {
       if (err) { cb(err); return; }
-      fs.mkdirpSync(dest);
-      fs.copy(paths.dist(lang), dest, function(err) {
+      fs.mkdirpSync(outputPath);
+      fs.copy(paths.dist(lang), outputPath, function(err) {
         version = readPackage().version;
         config.updatePackage(version, gitAdd);
       });
@@ -146,7 +208,7 @@ Object.keys(languages).forEach(function(lang) {
 
     function gitAdd(err) {
       if (err) { cb(err); return; }
-      echoAndExec('git add ' + paths.repoDestRelative(lang), {cwd: repoRoot}, gitCommit);
+      echoAndExec('git add ' + paths.repoOutputRelative(lang), {cwd: repoRoot}, gitCommit);
     }
 
     function gitCommit(err) {
@@ -163,11 +225,13 @@ Object.keys(languages).forEach(function(lang) {
       if (err) { cb(err); return; }
       echoAndExec(
           util.format('git push --tags origin %s', config.branch),
-          {cwd: repoRoot}, function(err, stdout, stderr) {
-        if (err) { cb(err); return; }
-        // Finally, success!
-        cb();
-      });
+          {cwd: repoRoot},
+          done);
+    }
+
+    function done(err, stdout, stderr) {
+      if (err) { cb(err); return; }
+      cb();
     }
   });
 });
@@ -211,40 +275,6 @@ gulp.task('ensure-git-clean', function() {
     if (!/working directory clean/.exec(out)) {
       throw new Error('Git working directory not clean, will not bump version');
     }
-  });
-});
-
-/**
- * Generate build rules for each resource in each language.
- */
-var resourceNames = resource.names();
-Object.keys(languages).forEach(function(lang) {
-
-  function taskName(resourceName) {
-    return 'build-' + lang + '-' + resourceName;
-  }
-
-  resourceNames.forEach(function(resourceName) {
-    gulp.task(taskName(resourceName), function() {
-      return gulp.src('src/templates/' + lang + '/resource.*.template')
-          .pipe(template(resource.load(resourceName), {
-            imports: helpers(lang),
-            variable: 'resource'
-          }))
-          .pipe(rename(function(path) {
-            path.extname = /^.*([.].*?)$/.exec(path.basename)[1];
-            path.basename = languages[lang].resourceBaseName(resourceName);
-          }))
-          .pipe(gulp.dest(paths.dist(lang)));
-    });
-  });
-
-  gulp.task('build-' + lang, ['clean-' + lang].concat(resourceNames.map(taskName)));
-});
-
-Object.keys(languages).forEach(function(lang) {
-  gulp.task('clean-' + lang, function() {
-    fs.removeSync(paths.dist(lang));
   });
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,7 +106,7 @@ Object.keys(languages).forEach(function(lang) {
   /**
    * Checkout target repo, for build and deploy
    */
-  gulp.task('checkout-' + lang, ['clean-', lang], function(cb) {
+  gulp.task('checkout-' + lang, ['clean-' + lang], function(cb) {
 
     cloneRepo(cb);
 
@@ -139,31 +139,31 @@ Object.keys(languages).forEach(function(lang) {
    * Build rules, per resource.
    */
   resourceNames.forEach(function(resourceName) {
-    gulp.task(resTaskName(resourceName), function() {
+    gulp.task(resTaskName(resourceName), ['checkout-' + lang], function() {
       // Support templates existing either locally or in target repo.
       var templatePath = config.templatePath ?
           (paths.repo(lang) + '/' + config.templatePath):
           ('src/templates/' + lang);
-      var resourceTemplateInfo = require(templatePath).resource;
+      var resourceTemplateInfo = require('./' + templatePath).resource;
 
       // Find the template info for resources
-      var resource = resource.load(resourceName);
+      var resourceInstance = resource.load(resourceName);
       var templateHelpers = helpers(lang);
       return gulp.src(templatePath + '/' + resourceTemplateInfo.template)
           .pipe(
-              template(resource, {
+              template(resourceInstance, {
                 imports: templateHelpers,
                 variable: 'resource'
               }))
           .pipe(
-              rename(resourceTemplateInfo.filename(resource, templateHelpers)))
+              rename(resourceTemplateInfo.filename(resourceInstance, templateHelpers)))
           .pipe(
               gulp.dest(paths.dist(lang)));
     });
   });
   gulp.task(
       'build-' + lang,
-      ['checkout-' + lang].concat(resourceNames.map(resTaskName)));
+      resourceNames.map(resTaskName));
 
   /**
    * Deploy

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asana-api-meta",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Metadata for Asana API for generating client libraries and documenation",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Instead of pushing to a separate `asana-gen` package, we now push to a branch of the actual client lib repo. Furthermore, the templates that build files for each client library can each exist in that repo.

Rewrote a bunch of gulp rules and rejiggered the config to handle this.