### PR TITLE
Rename api explorer and re-enable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,14 +53,12 @@ var languages = {
     templatePath: 'lib/templates',
     outputPath: 'lib/asana/resources',
     skip: ['event']
-/* disabled because we don't support private repos yet, cloning fails
   },
-  ts_tester: {
-    repo: 'Asana/node-asana-tester',
+  api_explorer: {
+    repo: 'Asana/api-explorer',
     branch: 'api-meta-incoming',
     templatePath: 'src/resources/templates',
     outputPath: 'src/resources/gen'
-*/
   }
 };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -115,7 +115,7 @@ var langs = {
     typeName: typeNameTranslator("ruby"),
     comment: wrapHashComment
   }),
-  ts_tester: _.merge({}, common, {
+  api_explorer: _.merge({}, common, {
     typeName: typeNameTranslator("js"),
     comment: wrapStarComment
   })


### PR DESCRIPTION
Since we've renamed and are open-sourcing the api explorer