### PR TITLE
[Api Explorer] Ignore eofline lint rule

### DIFF
--- a/src/templates/api_explorer/resource.ejs
+++ b/src/templates/api_explorer/resource.ejs
@@ -9,5 +9,6 @@ delete resource.templates;
  * errors that are just not worth fixing.
  */
 /* tslint:disable:max-line-length */
+/* tslint:disable:eofline */
 var resource = <Resource><%= JSON.stringify(resource, null, 2) %>;
 export = resource;


### PR DESCRIPTION
The updated build process (https://github.com/Asana/asana-api-meta/commit/04b6006b27b484ee80d7f80ce6d4e7f6a29be8af)
made it so there's no longer a newline. For some reason, adding a newline doesn't persist on
deployment, so let's just ignore the rule (it's not important for these files since they're codegen-ed).

```
$ npm run lint

> asana-api-explorer@0.0.0 lint /Users/ericpelz/sandbox/api-explorer
> find src test -name "*.ts" | sed 's/^/--file=/g' | xargs tslint

src/resources/gen/attachments.ts[170, 19]: file should end with a newline
src/resources/gen/events.ts[160, 19]: file should end with a newline
src/resources/gen/projects.ts[379, 19]: file should end with a newline
src/resources/gen/stories.ts[239, 19]: file should end with a newline
src/resources/gen/tags.ts[261, 19]: file should end with a newline
src/resources/gen/tasks.ts[778, 19]: file should end with a newline
src/resources/gen/teams.ts[101, 19]: file should end with a newline
src/resources/gen/users.ts[144, 19]: file should end with a newline
src/resources/gen/workspaces.ts[163, 19]: file should end with a newline
```