### PR TITLE
Allow users.find_by_id to properly handle user parameter string in Ruby

### DIFF
--- a/src/resources/user.yaml
+++ b/src/resources/user.yaml
@@ -78,6 +78,7 @@ actions:
       - name: user
         <<: *Param.User
         required: true
+        as_id: true
     comment: |
       Returns the full user record for the single user with the provided ID.
 

--- a/src/templates/ruby/resource.ejs
+++ b/src/templates/ruby/resource.ejs
@@ -80,7 +80,8 @@ function Action(action) {
     }
 
     // Endpoint path
-    this.path = _.reduce(this.idParams, function(acc, id) {
+    var tfmParams = _.filter(params, function(p) { return p.as_id || p.type == "Id" })
+    this.path = _.reduce(tfmParams, function(acc, id) {
         var localName = that.mainIdParam == id ? "id" : id.name
         return acc.replace("\%s", "#{" + localName + "}")
     }, action.path)


### PR DESCRIPTION
This template update corrects the users.find_by_id call in the Ruby binding to properly substitute the `user` parameter. A slightly different fix would change the API call to take a single argument (instead of the named user parameter), but this would cause an API change.

This is the templated version of Pull Request #34 in the Asana/ruby-asana project.