### PR TITLE
Allow tasks.find_all to accept project parameter

### DIFF
--- a/src/resources/task.yaml
+++ b/src/resources/task.yaml
@@ -365,6 +365,9 @@ actions:
         notes:
           - |
             If you specify `assignee`, you must also specify the `workspace` to filter on.
+      - name: project
+        <<: *Param.ProjectId
+        comment: The project to filter tasks on.
       - name: workspace
         <<: *Param.WorkspaceId
         comment: The workspace or organization to filter tasks on.


### PR DESCRIPTION
The backend API allows project to be a filter parameter to the /tasks endpoint, but the templates don't recognize this.  It's particularly useful when asking for tasks with modified_since in a particular project.

This change adds the project parameter to the /tasks endpoint.