### PR TITLE
Remove YAML that is no longer used

### DIFF
--- a/src/templates/api_reference/resource.ejs
+++ b/src/templates/api_reference/resource.ejs
@@ -22,11 +22,6 @@ side_nav:
     name: <%= action_class.name%>
     url: <%= action_class.url%>
 <%});%>
-
-# Header
-logo_text: Developers
-header_type: navigation
-header_search: true;
 ---
 
 ### <%= thisType%>


### PR DESCRIPTION
@praecipula We no longer use this YAML in our templates so I figured this would be the right place to get it removed from our API docs. Let me know if this isn't the correct way or if there's anything else I need to do/test for. Thanks! 