### PR TITLE
Deploy on tag only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ node_js:
 sudo: false
 after_success:
   if [ ! -z "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    echo "Deploying, issuing pull requests to api-meta-incoming"
-    git config --global user.email "git@asana.com"
-    git config --global user.name "Asana"
+    echo "Deploying, issuing pull requests to api-meta-incoming";
+    git config --global user.email "git@asana.com";
+    git config --global user.name "Asana";
     gulp deploy
   else
     echo "Skipping deployment"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: node_js
 node_js:
 - '0.10'
 sudo: false
-branches:
-  only:
-    - /^v[0-9]+\.[0-9]+\.[0-9]+/
-    - master
 after_success:
   if [ ! -z "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     echo "Deploying, issuing pull requests to api-meta-incoming"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 after_success:
   if ([ "$TRAVIS_BRANCH" == "master" ] || [ ! -z "$TRAVIS_TAG" ]) && 
       [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-    echo "Deploying: issuing pull requests to api-meta-incoming"
+    echo "Deploying, issuing pull requests to api-meta-incoming"
     - git config --global user.email "git@asana.com"
     - git config --global user.name "Asana"
     - gulp deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: false
 after_success:
   if [ ! -z "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     echo "Deploying, issuing pull requests to api-meta-incoming"
-    - git config --global user.email "git@asana.com"
-    - git config --global user.name "Asana"
-    - gulp deploy
+    git config --global user.email "git@asana.com"
+    git config --global user.name "Asana"
+    gulp deploy
   else
     echo "Skipping deployment"
   fi  

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ after_success:
     echo "Deploying, issuing pull requests to api-meta-incoming";
     git config --global user.email "git@asana.com";
     git config --global user.name "Asana";
-    gulp deploy
+    gulp deploy;
   else
-    echo "Skipping deployment"
+    echo "Skipping deployment";
   fi  
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ branches:
     - /^v[0-9]+\.[0-9]+\.[0-9]+/
     - master
 after_success:
-  if ([ "$TRAVIS_BRANCH" == "master" ] || [ ! -z "$TRAVIS_TAG" ]) && 
-      [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  if [ ! -z "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     echo "Deploying, issuing pull requests to api-meta-incoming"
     - git config --global user.email "git@asana.com"
     - git config --global user.name "Asana"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 branches:
   only:
     - /^v[0-9]+\.[0-9]+\.[0-9]+/
+    - master
 after_success:
   - git config --global user.email "git@asana.com"
   - git config --global user.name "Asana"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ after_success:
   else
     echo "Skipping deployment"
   fi  
-  - git config --global user.email "git@asana.com"
-  - git config --global user.name "Asana"
-  - gulp deploy
 env:
   global:
     - GULP_DEBUG=1


### PR DESCRIPTION
Travis has functionality to deploy on tagged builds only; this lets CI tests be run on general commits, but doesn't trigger the deploy unless the commit is _also_ a new Git tag. This is nice, and we do this in our client libraries. As it was with api-meta, we issued a "deploy" on every commit to master or a branch that "looked" like a tag, but I like the functionality of the "only deploy on tag" wasn't there, so we issued N pull requests on all client libraries for even minor updates to the master branch. There is a workaround available in Travis though; check env variables to see if there is a tag with an if statement in Bash, so this should (hopefully) do that.