### PR TITLE
Sets findByProject and findByWorkspace to return collection for custom fields

### DIFF
--- a/src/resources/custom_field_settings.yaml
+++ b/src/resources/custom_field_settings.yaml
@@ -3,7 +3,7 @@
 !include ../includes.yaml
 name: custom_field_settings
 comment: |
-  
+
   Custom fields are attached to a particular project with the Custom
   Field Settings resource. This resource both represents the many-to-many join
   of the Custom Field and Project as well as stores information that is relevant to that
@@ -21,9 +21,9 @@ properties:
     access: Read-only
     comment: |
       The time at which this custom field was created.
-  - name: is_important 
-    <<: *PropType.Bool 
-    access: Read-only 
+  - name: is_important
+    <<: *PropType.Bool
+    access: Read-only
     comment: |
       `is_important` is a flag that can be used in application-defined
       behavior: for instance, in the Asana web application, `is_important` is
@@ -58,6 +58,7 @@ actions:
         <<: *Param.ProjectId
         required: true
         comment: The ID of the project for which to list custom field settings
+    collection: true
     comment: |
       Returns a list of all of the custom fields settings on a project, in compact form. Note that, as in all queries to collections which return compact representation, `opt_fields` and `opt_expand` can be used to include more data than is returned in the compact representation. See the getting started guide on [input/output options](/developers/documentation/getting-started/input-output-options) for more information.
 

--- a/src/resources/custom_fields.yaml
+++ b/src/resources/custom_fields.yaml
@@ -3,7 +3,7 @@
 !include ../includes.yaml
 name: custom_fields
 comment: |
-  
+
   Custom Fields store the metadata that is used in order to add user-specified
   information to tasks in Asana. Be sure to reference the [Custom
   Fields](/developers/documentation/getting-started/custom-fields) developer
@@ -45,7 +45,7 @@ properties:
   - name: precision
     <<: *PropType.CustomFieldPrecision
     access: Read-only
-      
+
 
 action_classes:
   - name: Type-specific custom field information
@@ -82,5 +82,6 @@ actions:
         <<: *Param.WorkspaceId
         required: true
         comment: The workspace or organization to find custom field definitions in.
+    collection: true
     comment: |
       Returns a list of the compact representation of all of the custom fields in a workspace.


### PR DESCRIPTION
The CustomFieldSetting#findByProject and CustomField#findByWorkspace
definitions were not set to receive a collection, but the value for
`data` in these responses is an array. The implementations of these
methods (at least in the ruby client) raise errors. Setting this to
a collection should fix these issues when a new version of the libraries
are released.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/182694757936969/364724061575231)
