### PR TITLE
Make Warning in Static Site Header Valid YAML

### DIFF
--- a/src/templates/api_reference/partials/static_site_header.ejs
+++ b/src/templates/api_reference/partials/static_site_header.ejs
@@ -1,10 +1,10 @@
 ---
-***** WARNING *****
-
-This file is auto generated upon deploy of https://github.com/Asana/asana-api-meta. To contribute please
-familiarize yourself with the process as documented in the README.md found in that repository *****
-
-***** WARNING *****
+##### WARNING #####
+#
+# This file is auto generated upon deploy of https://github.com/Asana/asana-api-meta. To contribute please
+# familiarize yourself with the process as documented in the README.md found in that repository.
+# 
+##### WARNING #####
 
 
 parent-title: API Reference


### PR DESCRIPTION
The header section in the static site is a YAML document, and the `****` at the start of the lines was not valid YAML. The static site used to use a really loose parser, so this was OK, but that is no longer true. This just turns the banner into a YAML comment so it can parse correctly.